### PR TITLE
Add configurable control over the classpath.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.edugility</groupId>
   <artifactId>h2-maven-plugin</artifactId>
-  <version>1.1-SNAPSHOT</version>
+  <version>1.0.1-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <parent>

--- a/src/main/java/com/edugility/h2/maven/plugin/AbstractH2Mojo.java
+++ b/src/main/java/com/edugility/h2/maven/plugin/AbstractH2Mojo.java
@@ -185,7 +185,15 @@ public abstract class AbstractH2Mojo extends AbstractMojo {
    *
    * @parameter property="javaOptions"
    */
-  private String[] javaOptions;  
+  private String[] javaOptions;
+  
+  /**
+   * Any additions to the classpath.
+   *
+   * @parameter property="classpath"
+   */
+  private File[] classpath;
+
 
   /**
    * Creates a new {@link AbstractH2Mojo}.
@@ -417,6 +425,27 @@ public abstract class AbstractH2Mojo extends AbstractMojo {
    */
   public void setJavaOptions(final String... javaOptions) {
     this.javaOptions = javaOptions;
+  }
+
+  /**
+   * Returns any additional directories or JAR-files to be added
+   * to the classpath.
+   *
+   * @return any additional classpath entries for the spawned H2 process, or
+   * {@code null}
+   */
+  public File[] getClasspath() {
+    return this.classpath;
+  }
+
+  /**
+   * Sets any additional classpath entries to be passed to the Java runtime
+   * when spawning a new H2 TCP server.
+   *
+   * @param classpath the options; may be {@code null}
+   */
+  public void setClasspath(final File... classpath) {
+    this.classpath = classpath;
   }
 
   /**
@@ -684,9 +713,19 @@ public abstract class AbstractH2Mojo extends AbstractMojo {
     }
 
     args.add(argumentIndex++, "-cp");
+    StringBuffer cpAsText = new StringBuffer();
+    final File cp[] = this.getClasspath();
+    if (cp != null && cp.length > 0) {
+    	for (final File jarOrDirectory : cp) {
+    		if(jarOrDirectory != null) {
+    			cpAsText.append(jarOrDirectory.getAbsolutePath()).append(File.pathSeparatorChar);
+    		}
+    	}
+    }
     final File fileLocation = this.getH2();
     assert fileLocation != null;
-    args.add(argumentIndex++, fileLocation.getAbsolutePath());
+    cpAsText.append(fileLocation.getAbsolutePath());
+    args.add(argumentIndex++, cpAsText.toString());
 
     args.add(argumentIndex++, Server.class.getName());
 


### PR DESCRIPTION
Add entries to the front of the `-cp` that's handed to the `java` invocation. This is convenient for "stored procedures" aka H2 [user defined functions](http://www.h2database.com/html/features.html#user_defined_functions).

Configuration example:

```
<configuration>
    ...
    <classpath>
        <entry>target/test-classes</entry>
    </classpath>
</configuration>
```

This fixes https://github.com/ljnelson/h2-maven-plugin/issues/5 .

Please pull, and thank you for providing fine software.
